### PR TITLE
Add @unhead/react package to modify title and meta throughout the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="/assets/favicon/Favicon.ico"/>
 
-  <meta name="description"
-    content="Jhon Doe vous propose ses services en qualité de Dév Web Full Stack. information et contact sur le site.">
   <title>Accueil</title>
+  <meta name="description"
+    content="Jhon Doe vous propose ses services en qualité de Dév Web Full Stack. Page de présentation.">
 </head>
 
 <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
+        "@unhead/react": "^2.0.10",
         "bootstrap": "^5.3.5",
         "bootstrap-icons": "^1.13.1",
         "open-cli": "^8.0.0",
@@ -1998,6 +1999,21 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@unhead/react": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@unhead/react/-/react-2.0.10.tgz",
+      "integrity": "sha512-U5tqhUYk4qmyLD8YpKOuYwWmbIGFpB7aacOzcGAhjJ59GH3W/BSFOFHj/6dcoYV5yzr1CZrINGGH7stRVMMLjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "unhead": "2.0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.4.1.tgz",
@@ -3799,6 +3815,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -5983,6 +6005,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unhead": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.0.10.tgz",
+      "integrity": "sha512-GT188rzTCeSKt55tYyQlHHKfUTtZvgubrXiwzGeXg6UjcKO3FsagaMzQp6TVDrpDY++3i7Qt0t3pnCc/ebg5yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^5.5.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
       }
     },
     "node_modules/unique-string": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
+    "@unhead/react": "^2.0.10",
     "bootstrap": "^5.3.5",
     "bootstrap-icons": "^1.13.1",
     "open-cli": "^8.0.0",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,3 +1,4 @@
+import {createHead, UnheadProvider } from "@unhead/react/client";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
@@ -14,19 +15,23 @@ import Realisations from "pages/realisations.jsx";
 import Contact from "pages/contact.jsx";
 import LegalNotice from "pages/legal-notice.jsx";
 
+const head = createHead();
+
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <Router>
-      <ScrollToTop />
-      <Routes>
-        <Route path="/" element={<App />}>
-          <Route index element={<Home />} />
-          <Route path="services" element={<Services />} />
-          <Route path="realisations" element={<Realisations />} />
-          <Route path="contact" element={<Contact />} />
-          <Route path="legal-notice" element={<LegalNotice />} />
-        </Route>
-      </Routes>
-    </Router>
+    <UnheadProvider head={head}>
+      <Router>
+        <ScrollToTop />
+        <Routes>
+          <Route path="/" element={<App />}>
+            <Route index element={<Home />} />
+            <Route path="services" element={<Services />} />
+            <Route path="realisations" element={<Realisations />} />
+            <Route path="contact" element={<Contact />} />
+            <Route path="legal-notice" element={<LegalNotice />} />
+          </Route>
+        </Routes>
+      </Router>
+    </UnheadProvider>
   </StrictMode>
 );

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -1,3 +1,5 @@
+import { Head } from '@unhead/react';
+
 import { Presentation, SectionTitle} from "jsx/components"
 import { ContactList } from 'jsx/contact-card'
 import { useRef } from 'react';
@@ -21,6 +23,10 @@ export default function ContactPage(){
 
   return(
       <>
+        <Head>
+          <title>Contact</title>
+          <meta name="description" content="Acces au formulaire de contact ainsi qu'à l'adresse professionnelle via la minimap" />
+        </Head>
         <Presentation title= "Contact" description= "Pour me contacte en vue d'un entretien  ou d'une future collaboration, merci de remplir le formulaire de contact."/>
         <div className= "p-4 shadow rounded contact-box">
           <section className="contact-section">

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -1,3 +1,4 @@
+import { Head } from '@unhead/react';
 import { useState, useEffect } from 'react'
 import React from 'react'
 import { Link } from 'react-router-dom'
@@ -105,6 +106,10 @@ const commonDivClass = "app_modal-contentBox";
 export default function HomePage() {
   return(
     <>
+      <Head>
+        <title>Accueil</title>
+        <meta name="description" content="Jhon Doe vous propose ses services en qualité de Dév Web Full Stack. Page de présentation."/>
+      </Head>
       <div className="app_introductionContainer">
         <HeroBg/>
         <div className="app_introductionContainer-box">

--- a/src/pages/legal-notice.jsx
+++ b/src/pages/legal-notice.jsx
@@ -1,35 +1,45 @@
-import { Presentation } from "jsx/components"
+import { Head } from '@unhead/react';
+
+import { Presentation } from "jsx/components";
 import { DetailsAccordion } from 'jsx/accordion';
-import { CreditText } from "jsx/text"
-import { ContactList } from "jsx/contact-card"
+import { CreditText } from "jsx/text";
+import { ContactList } from "jsx/contact-card";
 
 export default function LegalNoticePage() {
-  return(
-    <div className = "app_mainContainer">
-        <Presentation
-            title = "Mentions légales"
-            description = {false}
-        />
-        <section className="accordion-container app_accordionContainer">
-            <DetailsAccordion
-                title = "Editeur du site"
-                text = {<ContactList selectedIds={["editor"]} showIcon={true} />}
-                id = "editor"
-            />
 
-            <DetailsAccordion
-                title = "Hébergeur"
-                text = {<ContactList selectedIds={["host"]} showIcon={true}/>}
-                id = "host"
-            />
+    return(
+        <>
+            <Head>
+                <title>Mentions Légales</title>
+                <meta name="description" content="Page concernant les mentions légales"/>
+                <meta name="robots" content="noindex, nofollow"/>
+            </Head>
+            
+            <div className = "app_mainContainer">
+                <Presentation
+                    title = "Mentions légales"
+                    description = {false}
+                />
+                <section className="accordion-container app_accordionContainer">
+                    <DetailsAccordion
+                        title = "Editeur du site"
+                        text = {<ContactList selectedIds={["editor"]} showIcon={true} />}
+                        id = "editor"
+                    />
 
-            <DetailsAccordion
-                title = "Crédit"
-                text = {<CreditText />}
-                id = "credit"
-            />
-        </section>
-    </div>
-  )
+                    <DetailsAccordion
+                        title = "Hébergeur"
+                        text = {<ContactList selectedIds={["host"]} showIcon={true}/>}
+                        id = "host"
+                    />
+
+                    <DetailsAccordion
+                        title = "Crédit"
+                        text = {<CreditText />}
+                        id = "credit"
+                    />
+                </section>
+            </div>
+        </>
+    )
 }
- 

--- a/src/pages/realisations.jsx
+++ b/src/pages/realisations.jsx
@@ -1,3 +1,5 @@
+import { Head } from '@unhead/react';
+
 import { BannerBg } from "jsx/images"
 import { Presentation } from "jsx/components"
 import { useEffect } from "react"
@@ -21,6 +23,10 @@ const RealisationsPage = () => {
     }, [ hash ]);
     return (
         <>
+            <Head>
+                <title>Portfolio</title>
+                <meta name="description" content="Page regroupant les différentes réalisations" />
+            </Head>
             <BannerBg/>
             <Presentation title = "Portfolio" description = "Voici quelques unes de mes réalisations."/>
             <RealisationsList selectedIds ={['coder', 'bienetre', 'freshfood', 'restaujap', 'screens','seo']}/>

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -1,3 +1,5 @@
+import { Head } from '@unhead/react';
+
 import { BannerBg } from "jsx/images"
 import { Presentation } from "jsx/components"
 import { ServicesList } from "jsx/service-card"
@@ -5,6 +7,10 @@ import { ServicesList } from "jsx/service-card"
 export default function ServicesPage() {
   return(
     <>
+      <Head>
+        <title>Services</title>
+        <meta name="description" content="Page regroupant les services proposés"/>
+      </Head>
       <BannerBg/>
       <Presentation title = "Mon offre de services" description = "Voici les prestations sur lequelles je peux intervenir" />
       <ServicesList selectedIds = {['uxdesign', 'dev', 'ref']}/>


### PR DESCRIPTION
This PR implements the @unhead/react package to allow dynamic modification
of page titles and meta tags for SEO purposes, specifically for handling
'noindex' directives.

Helmet async package the last version, 2022, doesn't work properly on React 19 as it is not as maintained as unhead.

 CLOSES #32